### PR TITLE
Align quote API route with frontend

### DIFF
--- a/api/send-quote.ts
+++ b/api/send-quote.ts
@@ -20,7 +20,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     // Expect JSON body from client
-    const { customerEmail, customerName, quote, meta } = (req as any).body || {};
+    type QuoteRequestBody = {
+      customerEmail?: string;
+      customerName?: string;
+      quote?: string;
+      meta?: unknown;
+    };
+
+    const { customerEmail, customerName, quote, meta } = (req.body ?? {}) as QuoteRequestBody;
     if (!customerEmail || !quote) {
       return res.status(400).json({ error: 'Missing fields: customerEmail and quote are required.' });
     }
@@ -120,8 +127,9 @@ ${meta ? JSON.stringify(meta, null, 2) : '—'}`;
     await sendEmail(OWNER_EMAIL, `New Quote Request from ${customerName || customerEmail}`, ownerText, ownerHtml);
 
     return res.status(200).json({ ok: true });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error(err);
-    return res.status(500).json({ error: err?.message || 'Email send failed' });
+    const message = err instanceof Error ? err.message : 'Email send failed';
+    return res.status(500).json({ error: message });
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
     "functions": {
         "api/*.ts": {
-            "runtime": "@vercel/node"
+            "runtime": "@vercel/node@5.3.23"
         }
     }
 }


### PR DESCRIPTION
## Summary
- rename the serverless Mailgun handler to `api/send-quote.ts` so the deployed route matches the quote form submission
- tighten the handler's request parsing and error handling to avoid `any` usage and improve responses
- pin the Vercel functions runtime to `@vercel/node@5.3.23` so builds accept the configuration

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68cf9b99d164832c85ee1728ee2e12ca