### PR TITLE
Handle JSON body parsing for send-quote endpoint

### DIFF
--- a/api/send-quote.ts
+++ b/api/send-quote.ts
@@ -1,7 +1,17 @@
 // api/send-quote.ts
-import type { VercelRequest, VercelResponse } from '@vercel/node';
+import type { IncomingMessage, ServerResponse } from 'http';
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
+// Minimal request/response shapes so we don't depend on `@vercel/node` types at build time.
+type VercelLikeRequest = IncomingMessage & {
+  body?: unknown;
+};
+
+type VercelLikeResponse = ServerResponse & {
+  status: (statusCode: number) => VercelLikeResponse;
+  json: (body: unknown) => VercelLikeResponse;
+};
+
+export default async function handler(req: VercelLikeRequest, res: VercelLikeResponse) {
   // CORS (allow POST from your site; keep '*' if you truly need any origin)
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');


### PR DESCRIPTION
## Summary
- normalize the send-quote handler body parsing so string or Buffer payloads are parsed before use
- return an explicit 400 response when invalid JSON is provided

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfa241ada8832c8204ebec91d7f1d4