### PR TITLE
Add Devon's One Call logo to header

### DIFF
--- a/src/assets/devon-logo.svg
+++ b/src/assets/devon-logo.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="360" viewBox="0 0 900 360" role="img" aria-labelledby="title desc">
+  <title id="title">Devon's One Call Handyman Services Logo</title>
+  <desc id="desc">A dark background logo with a roofline, handyman tools, and gold typography for Devon's One Call Handyman Services.</desc>
+  <rect width="900" height="360" fill="#1b1b1d" rx="18" />
+  <g fill="#f4c542">
+    <text x="450" y="70" font-family="'Montserrat', 'Helvetica Neue', Arial, sans-serif" font-size="40" font-weight="700" letter-spacing="4" text-anchor="middle">
+      DEVON'S ONE CALL
+    </text>
+    <text x="450" y="110" font-family="'Montserrat', 'Helvetica Neue', Arial, sans-serif" font-size="34" font-weight="600" letter-spacing="3" text-anchor="middle">
+      HANDYMAN SERVICES
+    </text>
+    <path d="M120 190 L260 120 L400 190" fill="none" stroke="#f4c542" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+    <rect x="400" y="178" width="360" height="12" rx="6" />
+    <path d="M650 180 L780 110 L780 290" fill="none" stroke="#f4c542" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
+  <g fill="#f4c542">
+    <g transform="translate(160 200)">
+      <rect x="-10" y="0" width="20" height="90" rx="6" />
+      <rect x="-30" y="30" width="60" height="24" rx="6" />
+      <circle cx="20" cy="42" r="4" fill="#1b1b1d" />
+    </g>
+    <g transform="translate(240 200)">
+      <rect x="-18" y="0" width="36" height="58" rx="6" />
+      <rect x="-24" y="58" width="48" height="14" />
+      <rect x="-12" y="72" width="24" height="32" rx="4" />
+    </g>
+    <g transform="translate(320 200)">
+      <rect x="-14" y="0" width="28" height="60" rx="6" />
+      <rect x="-24" y="60" width="48" height="18" />
+      <path d="M0 78 L-10 110 L10 110 Z" />
+    </g>
+    <g transform="translate(400 200)">
+      <rect x="-9" y="0" width="18" height="52" rx="6" />
+      <rect x="-4" y="52" width="8" height="70" />
+      <path d="M0 122 L-16 150 L16 150 Z" />
+    </g>
+    <g transform="translate(480 200)">
+      <rect x="-12" y="0" width="24" height="40" rx="6" />
+      <rect x="-28" y="40" width="56" height="18" rx="6" />
+      <path d="M0 58 C-16 58 -28 72 -28 86 C-28 100 -16 114 0 114 C16 114 28 100 28 86 C28 72 16 58 0 58 Z" stroke="#1b1b1d" stroke-width="6" fill="none" />
+      <circle cx="0" cy="86" r="8" />
+    </g>
+    <g transform="translate(560 200)">
+      <path d="M0 0 L-14 80 L14 80 Z" />
+      <rect x="-6" y="80" width="12" height="70" />
+    </g>
+    <g transform="translate(640 200)">
+      <circle cx="0" cy="60" r="42" fill="none" stroke="#f4c542" stroke-width="10" />
+      <circle cx="0" cy="60" r="16" />
+      <rect x="-8" y="-10" width="16" height="32" transform="rotate(20)" />
+      <rect x="-8" y="88" width="16" height="32" transform="rotate(20)" />
+      <rect x="-50" y="36" width="16" height="32" transform="rotate(-70)" />
+      <rect x="34" y="52" width="16" height="32" transform="rotate(-70)" />
+    </g>
+    <g transform="translate(720 200)">
+      <rect x="-18" y="0" width="36" height="160" />
+      <rect x="-18" y="0" width="36" height="32" fill="#1b1b1d" />
+      <rect x="-18" y="48" width="36" height="12" fill="#1b1b1d" />
+      <rect x="-18" y="82" width="36" height="12" fill="#1b1b1d" />
+      <rect x="-18" y="116" width="36" height="12" fill="#1b1b1d" />
+    </g>
+  </g>
+</svg>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
-import { Hammer, ShoppingCart } from 'lucide-react';
+import { ShoppingCart } from 'lucide-react';
+import devonLogo from '../assets/devon-logo.svg';
 import { useCart } from '../context/CartContext';
 
 interface HeaderProps {
@@ -14,16 +15,18 @@ export default function Header({ currentView, setCurrentView }: HeaderProps) {
     <header className="bg-gray-800 shadow-lg sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
-          <div
-            className="flex items-center space-x-2 cursor-pointer"
+          <button
+            type="button"
+            className="flex items-center space-x-3 cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800"
             onClick={() => setCurrentView('home')}
           >
-            <Hammer className="h-8 w-8 text-yellow-400" />
-            <div>
-              <h1 className="text-xl font-bold text-white">Devon McCleese</h1>
-              <p className="text-sm text-yellow-400">Clay &amp; Duval County Handyman</p>
-            </div>
-          </div>
+            <img
+              src={devonLogo}
+              alt="Devon's One Call Handyman Services logo"
+              className="h-16 w-auto drop-shadow-lg"
+            />
+            <span className="sr-only">Go to Devon McCleese Handyman Services home</span>
+          </button>
 
           <nav className="hidden md:flex items-center space-x-8">
             <button


### PR DESCRIPTION
## Summary
- add a Devon's One Call Handyman Services logo graphic to the project assets
- replace the header icon with the new logo while preserving accessibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfe1faf5d4832c9bfe27d08988b5df